### PR TITLE
feat: use different profile when accessing ssm

### DIFF
--- a/src-tauri/src/aws.rs
+++ b/src-tauri/src/aws.rs
@@ -163,7 +163,6 @@ pub async fn db_secret(
     possible_secrets.push(format!("{}-{}/db-credentials", name, env));
     possible_secrets.push(format!("{}-{}/spring-datasource-password", name, env));
     possible_secrets.push(format!("{}-{}/datasource-password", name, env));
-    dbg!(&possible_secrets);
 
     let secret_client = secretsmanager::Client::new(&config);
 
@@ -173,10 +172,14 @@ pub async fn db_secret(
             .values(&secret)
             .build();
         let secret_arn = secret_client.list_secrets().filters(filter).send().await;
-
+        if secret_arn.is_err() {
+            return Err(BError::new("db_secret", "Auth error?"));
+        }
         let secret_arn = secret_arn.expect("Failed to fetch!");
+        
         let secret_arn = secret_arn.secret_list();
         if secret_arn.len() == 1 {
+
             let secret_arn = secret_arn.first().unwrap_or_log();
             let secret_arn = secret_arn.arn().expect("Expected arn password");
 

--- a/src-tauri/src/aws.rs
+++ b/src-tauri/src/aws.rs
@@ -189,7 +189,7 @@ pub async fn db_secret(
                 .send()
                 .await;
             if secret.is_err() {
-                return Err(BError::new("db_secret", "No secrets found"));
+                return Err(BError::new("db_secret", "No secret found"));
             }
             let secret = secret.unwrap_or_log();
             let secret = secret.secret_string().expect("There should be a secret");
@@ -250,7 +250,7 @@ pub async fn db_secret(
         }
     }
 
-    return Err(BError::new("db_secret", "No secrets found"));
+    return Err(BError::new("db_secret", "No secret found"));
 }
 
 pub async fn databases(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -390,7 +390,7 @@ async fn db_credentials(
 ) -> Result<DbSecret, BError> {
     let user_config = user_config.0.lock().await;
     let ssm_role = user_config.ssm_role.as_ref().unwrap_or_log();
-    let infra_default_role = format!("{}-{}", &db.name, "infra");
+    let infra_default_role = &db.name;
     let profile_name = ssm_role
         .get(&db.name)
         .unwrap_or(&infra_default_role);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1325,7 +1325,7 @@ async fn start_aws_ssm_proxy(
     ]);
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
-    info!("Execudtnig cmd: {:?} ", command);
+    info!("Executnig cmd: {:?} ", command);
     let shared_child = SharedChild::spawn(&mut command).unwrap_or_log();
     let shared_child_arc = Arc::new(shared_child);
     let child_arc_clone = shared_child_arc.clone();

--- a/src-tauri/src/user.rs
+++ b/src-tauri/src/user.rs
@@ -51,6 +51,7 @@ pub struct UserConfig {
     pub preffered_environments: Vec<Env>,
     pub logs_dir: Option<PathBuf>,
     pub last_selected_apps: Option<Vec<String>>,
+    pub ssm_role: Option<HashMap<TrackedName, String>>,
 }
 
 impl UserConfig {
@@ -104,6 +105,7 @@ impl UserConfig {
                 preffered_environments: vec![Env::DEV, Env::DEMO, Env::PROD],
                 logs_dir: Some(UserConfig::logs_path()),
                 last_selected_apps: Some(vec![]),
+                ssm_role: Some(HashMap::new()),
             };
             new_config.save();
             let _ = fs::remove_file(UserConfigOld::config_path());
@@ -125,6 +127,7 @@ impl UserConfig {
                 preffered_environments: vec![Env::DEV, Env::DEMO, Env::PROD],
                 logs_dir: Some(UserConfig::logs_path()),
                 last_selected_apps: Some(vec![]),
+                ssm_role: Some(HashMap::new()),
             },
         };
 
@@ -137,6 +140,9 @@ impl UserConfig {
         }
         if user_config.last_selected_apps.is_none() {
             user_config.last_selected_apps = Some(vec![]);
+        }
+        if user_config.ssm_role.is_none() {
+            user_config.ssm_role = Some(HashMap::new());
         }
 
         user_config

--- a/src/lib/componets/db-secret-btn.svelte
+++ b/src/lib/componets/db-secret-btn.svelte
@@ -26,7 +26,7 @@
 					await writeText(credentials.password);
 				}
 			} catch (e) {
-				message(`Credentials not found for ${database?.name}`, { title: 'Ooops!', type: 'error' });
+				message(`Credentials not found for ${database?.name}.\n Did you configure profile for ${database?.name} database?\n\nhttps://github.com/dwilkolek/wombat/wiki/Configuration#setup-profile-to-access-ssmparameter-store`, { title: 'Ooops!', type: 'error' });
 			}
 		}
 	};

--- a/src/lib/componets/error-box.svelte
+++ b/src/lib/componets/error-box.svelte
@@ -3,8 +3,8 @@
 </script>
 
 {#if $error}
-	<div class="alert alert-error shadow-lg fixed bottom-0">
-		<div>
+	<div class="alert alert-error shadow-lg fixed bottom-0 rounded-b-[0px]">
+		<div class="flex items-center gap-2">
 			<button
 				on:click={() => {
 					error.set(undefined);
@@ -23,7 +23,14 @@
 					/></svg
 				>
 			</button>
-			<span>{$error}</span>
+			{#if $error === 'No secret found'}
+				<div>Secret to databse not found. See: <a 
+					class="ttext-red-950 underline"
+					target="_blank" href="https://github.com/dwilkolek/wombat/wiki/Configuration#setup-profile-to-access-ssmparameter-store">
+				Configuration: Setup profile to access ssm/parameter store</a></div>
+			{:else}
+				<span>{$error}</span>
+			{/if}
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
By default when accessing ssm/parameter store app will use profile:
1. override value set in wombat config file in `ssm_role`. `key=<db name>, value=<profile>`
2. otherwise `<db_name>`
3. fallback to user profile name


```
File: ~/.aws/config

[profile dev]
sso_start_url = https://<org name>.awsapps.com/start
sso_region = eu-west-1
sso_account_id = 123123123
sso_role_name = dev_role
region = eu-west-1

[profile dba]
role_arn = arn:aws:iam::123123123:role/dba-infra
source_profile = dev

[profile dbc-infra]
role_arn = arn:aws:iam::123123123:role/dbc-infra
source_profile = dev
```

```
File: ~/.wombat_v1

...
  "ssm_role": {
    "dba": "dba", //optional, cause the same as default
    "dbc": "dbc-infra"
  }
}
```