### PR TITLE
fix: force GHA to use newer libwebkit2gtk for linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,10 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1=2.44.0-2 \
+            libwebkit2gtk-4.1-dev=2.44.0-2;
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
I found a thread saying this was the issue with the tauri appimages for nixos. Could you try it on a release, and I'll check if the appimage will work for me.

Here is the thread if you're interested:
https://github.com/gitbutlerapp/gitbutler/issues/5282